### PR TITLE
    Fix for issue #1555 and #1620: Page path rewriting when published page becomes the HOME page

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -109,7 +109,7 @@ class CMSChangeList(ChangeList):
         # tree using a stack now)
         pages = self.get_query_set(request).drafts().order_by('tree_id',  'lft').select_related()
         
-        
+
         # Get lists of page IDs for which the current user has 
         # "permission to..." on the current site. 
         perm_edit_ids = Page.permissions.get_change_id_list(request.user, site)

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from distutils.version import LooseVersion
 from django import template
 from django.conf import settings
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.util import get_deleted_objects
 from urllib2 import unquote

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from distutils.version import LooseVersion
 from django import template
 from django.conf import settings
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.util import get_deleted_objects
 from urllib2 import unquote
@@ -278,7 +278,6 @@ class PageAdmin(ModelAdmin):
                 pass
             else:
                 obj.move_to(target, position)
-
         Title.objects.set_or_create(
             request,
             obj,
@@ -1067,6 +1066,9 @@ class PageAdmin(ModelAdmin):
                 if page.published or is_valid_url(page.get_absolute_url(),page,False):
                     page.published = not page.published
                     page.save()
+                    if page.publisher_public:
+                        page.publisher_public.published = page.published
+                        page.publisher_public.save()
                 return jsonify_request(HttpResponse(admin_utils.render_admin_menu_item(request, page).content))
             except ValidationError,e:
                 return jsonify_request(HttpResponseBadRequest(e.messages))

--- a/cms/models/query.py
+++ b/cms/models/query.py
@@ -94,7 +94,7 @@ class PageQuerySet(PublisherQuerySet):
 
     def get_home(self, site=None):
         try:
-            home = self.published(site).all_root().order_by("tree_id")[0]
+            home = self.on_site(site).filter(published=True).all_root().order_by("tree_id")[0]
         except IndexError:
             raise NoHomeFound('No Root page found. Publish at least one page!')
         return home

--- a/cms/signals.py
+++ b/cms/signals.py
@@ -236,14 +236,15 @@ def update_placeholders(instance, **kwargs):
 def invalidate_menu_cache(instance, **kwargs):
     menu_pool.clear(instance.site_id)
 
-def check_if_page_is_home(instance, **kwargs):
-    instance.is_current_home_page = instance.is_home()
+def check_if_deleted_page_was_home(instance, **kwargs):
+    instance.is_home_page_at_deletion = instance.is_home()
 
-def reset_home_page_paths(instance, **kwargs):
+def adjust_path_of_new_home_page(instance, **kwargs):
     """If the page that got deleted was the home page, we need to reset 
     the paths of the page which became the new home page.
     """
-    if instance.is_current_home_page:
+    # the attribute name now translates to 'was_home_page_at_deletion'
+    if instance.is_home_page_at_deletion:
         try:
             new_home = instance.get_object_queryset().get_home()
         except NoHomeFound:
@@ -260,8 +261,8 @@ signals.post_save.connect(post_save_page, sender=Page)
 signals.post_save.connect(update_placeholders, sender=Page)
 signals.pre_save.connect(invalidate_menu_cache, sender=Page)
 signals.pre_delete.connect(invalidate_menu_cache, sender=Page)
-signals.pre_delete.connect(check_if_page_is_home, sender=Page)
-signals.post_delete.connect(reset_home_page_paths, sender=Page)
+signals.pre_delete.connect(check_if_deleted_page_was_home, sender=Page)
+signals.post_delete.connect(adjust_path_of_new_home_page, sender=Page)
 
 def pre_save_user(instance, raw, **kwargs):
     clear_user_permission_cache(instance)

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -25,6 +25,7 @@ URL_CMS_PLUGIN_ADD = urljoin(URL_CMS_PAGE_CHANGE, "add-plugin/")
 URL_CMS_PLUGIN_EDIT = urljoin(URL_CMS_PAGE_CHANGE, "edit-plugin/")
 URL_CMS_PLUGIN_REMOVE = urljoin(URL_CMS_PAGE_CHANGE, "remove-plugin/")
 URL_CMS_TRANSLATION_DELETE = urljoin(URL_CMS_PAGE_CHANGE, "delete-translation/")
+URL_CMS_PAGE_CHANGE_STATUS = urljoin(URL_CMS_PAGE_CHANGE, "change-status/")
 
 
 class _Warning(object):


### PR DESCRIPTION
- when CMS_MODERATOR = True:
    if the draft page is unpublished, the public version is also unpublished
- when determining the home page, ignore publication_date and publication_end_date this ensures that the home page path rewriting logic happens even if the page will only become available somewhere in the future
- change the post_save_page signal handler so that it also updates the:
    *\* paths(titles) of the currently saved page
    *\* if the currently saved page becomes the new home page, then update the paths(titles) of the previous home page
    *\* if the currently saved page used to be the home page, then update the paths(titles) of the new home page
- add pre/post delete signal handlers that: if the currently deleted page was the home page
    then update the path of the new home page
- Added unit tests for all the above functionality

This ensures that:
- we will always have AT MOST one page with the '' (empty) path
- the generated paths are consistent regardless of what publishing method is being used (tick the publish/unpublish checkbox in the page hierarchy, tick the 'is published' checkbox from the 'change page' view OR click 'publish' while doing frontend editing)
