### PR TITLE
Page form field choices - performance improvement

### DIFF
--- a/cms/forms/utils.py
+++ b/cms/forms/utils.py
@@ -84,8 +84,8 @@ def get_page_choices(lang=None):
     all_page_choices = [('', '----')]
     for site_id, site_name in site_choices:
         page_choices = cached_page_choices.get(cache_key_names[site_id])
-        page_choices = page_choices or new_choices.get(site_id, {}).items()
-        all_page_choices.append((site_name, page_choices))
+        page_choices = page_choices or new_choices.get(site_id, {})
+        all_page_choices.append((site_name, page_choices.items()))
     return all_page_choices
 
 

--- a/cms/forms/utils.py
+++ b/cms/forms/utils.py
@@ -14,25 +14,28 @@ from django.utils.safestring import mark_safe
 
 def update_site_and_page_choices(lang=None):
     lang = lang or translation.get_language()
-    SITE_CHOICES_KEY = get_site_cache_key(lang)
-    PAGE_CHOICES_KEY = get_page_cache_key(lang)
+    return get_site_choices(lang), get_page_choices(lang)
+
+
+def _fetch_page_choices(lang=None, sites=None):
+    lang = lang or translation.get_language()
+    sites = sites or Site.objects.values_list('id', flat=True)
+
+    fallback_langs = i18n.get_fallback_languages(lang)
+    langs = [lang] + fallback_langs
+
     if settings.CMS_MODERATOR:
         title_queryset = Title.objects.filter(page__publisher_is_draft=False)
     else:
         title_queryset = Title.objects.filter(page__publisher_is_draft=True)
+    title_queryset = title_queryset.filter(
+        language__in=langs, page__site__in=sites)
     ordering = ('page__site', 'page__tree_id', 'page__lft', 'page__rght')
+    fields = ('page__site', 'page', 'page__level', 'title', 'language')
+    titles_values = title_queryset.order_by(*ordering).values_list(*fields)
 
-    titles_data = ('page__site', 'page__site__name',
-                   'page', 'page__level', 'title', 'language')
-
-    fallback_langs = i18n.get_fallback_languages(lang)
-    langs = [lang] + fallback_langs
-    titles_values = title_queryset.filter(language__in=langs)\
-        .order_by(*ordering).values_list(*titles_data)
-
-    sites_dict, pages_dict = {}, defaultdict(SortedDict)
-    for site_id, site_name, page_id, page_lvl, title, _lang in titles_values:
-        sites_dict.setdefault(site_id, site_name)
+    pages_dict = defaultdict(SortedDict)
+    for site_id, page_id, page_lvl, title, _lang in titles_values:
         # overwrite fallback title if it was set since this is the
         #       requested language
         overwrite = _lang == lang
@@ -43,53 +46,66 @@ def update_site_and_page_choices(lang=None):
         if overwrite or set_fallback:
             pages_dict[site_id][page_id] = mark_safe(
                 u"%s%s" % (u"&nbsp;&nbsp;" * page_lvl, title))
+    return pages_dict
 
-    site_choices = sites_dict.items()
-    page_choices = [('', '----')]
-    for site_id, site_name in sites_dict.items():
-        page_choices.append((site_name, pages_dict[site_id].items()))
-
-    # We set it to 1 day here because we actively invalidate this cache.
-    cache.set(SITE_CHOICES_KEY, site_choices, 86400)
-    cache.set(PAGE_CHOICES_KEY, page_choices, 86400)
-    return site_choices, page_choices
 
 def get_site_choices(lang=None):
-    lang = lang or translation.get_language()
-    site_choices = cache.get(get_site_cache_key(lang))
+    # preserve function's signature even if lang is not used
+    SITE_CHOICES_KEY = get_site_cache_key()
+    site_choices = cache.get(SITE_CHOICES_KEY)
     if site_choices is None:
-        site_choices, page_choices = update_site_and_page_choices(lang)
+        if settings.CMS_MODERATOR:
+            sites_qs = Site.objects.filter(page__publisher_is_draft=False)
+        else:
+            sites_qs = Site.objects.filter(page__publisher_is_draft=True)
+
+        site_choices = list(sites_qs.values_list('id', 'name').distinct())
+        cache.set(SITE_CHOICES_KEY, site_choices, 86400)
     return site_choices
+
 
 def get_page_choices(lang=None):
     lang = lang or translation.get_language()
-    page_choices = cache.get(get_page_cache_key(lang))
-    if page_choices is None:
-        site_choices, page_choices = update_site_and_page_choices(lang)
-    return page_choices
+    site_choices = get_site_choices(lang)
+    site_ids = [site_id for site_id, _ in site_choices]
+    cache_key_names = {site_id: get_page_cache_key(lang, site_id)
+                       for site_id in site_ids}
+    cached_page_choices = cache.get_many(cache_key_names.values())
+    not_found_in_cache = [
+        site_id
+        for site_id in site_ids
+        if cache_key_names[site_id] not in cached_page_choices]
+    # fetch new page choices
+    new_choices = _fetch_page_choices(lang, not_found_in_cache)
+    cache.set_many({cache_key_names[site_id]: page_choices
+                    for site_id, page_choices in new_choices.items()}, 86400)
 
-def _get_key(prefix, lang):
-    return "%s-%s" % (prefix, lang)
+    # make choice list
+    all_page_choices = [('', '----')]
+    for site_id, site_name in site_choices:
+        page_choices = cached_page_choices.get(cache_key_names[site_id])
+        page_choices = page_choices or new_choices.get(site_id, {}).items()
+        all_page_choices.append((site_name, page_choices))
+    return all_page_choices
 
-def get_site_cache_key(lang):
-    return _get_key(settings.CMS_SITE_CHOICES_CACHE_KEY, lang)
 
-def get_page_cache_key(lang):
-    return _get_key(settings.CMS_PAGE_CHOICES_CACHE_KEY, lang)
+def get_site_cache_key(lang=None):
+    # preserve function's signature even if lang is not used
+    return settings.CMS_SITE_CHOICES_CACHE_KEY
 
-def _clean_many(prefix):
-    keys = []
-    for lang in [language[0] for language in settings.LANGUAGES]:
-        keys.append(_get_key(prefix, lang))
-    cache.delete_many(keys)
+def get_page_cache_key(lang, site_id):
+    return '-'.join((settings.CMS_PAGE_CHOICES_CACHE_KEY, lang, str(site_id)))
+
 
 def clean_site_choices_cache(sender, **kwargs):
-    _clean_many(settings.CMS_SITE_CHOICES_CACHE_KEY)
+    cache.delete(get_site_cache_key())
 
-def clean_page_choices_cache(sender, **kwargs):
-    _clean_many(settings.CMS_PAGE_CHOICES_CACHE_KEY)
+
+def clean_page_choices_cache(sender, instance, **kwargs):
+    cache.delete_many([get_page_cache_key(lang[0], instance.site_id)
+                       for lang in settings.LANGUAGES])
 
 post_save.connect(clean_page_choices_cache, sender=Page)
-post_save.connect(clean_site_choices_cache, sender=Site)
 post_delete.connect(clean_page_choices_cache, sender=Page)
+post_save.connect(clean_site_choices_cache, sender=Site)
 post_delete.connect(clean_site_choices_cache, sender=Site)


### PR DESCRIPTION
Having a cms project with CMS_MODERATOR on False, one language and 12483 page titles in the database(all linked to draft pages), the following was executed:

python -m timeit -v -n 1 -r 20 -s "from cms.forms.utils import update_site_and_page_choices; from django.core.cache import cache; cache.clear()" "update_site_and_page_choices('en')"

Results before these changes:
raw times: 3.18 2.74 2.85 3.59 3.27 3.32 3.71 3.31 2.85 2.74 2.77 2.79 2.78 2.96 2.78 2.81 2.78 3.04 2.94 2.96
1 loops, best of 20: 2.74 sec per loop

Results after these changes:
raw times: 0.681 0.597 0.675 0.589 0.579 0.597 0.589 0.573 0.606 0.584 0.594 0.579 0.58 0.595 0.596 0.625 0.62 0.64 0.666 0.601
1 loops, best of 20: 573 msec per loop
