### PR TITLE
* get_object_queryset should return a queryset without evaluation;

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -928,7 +928,9 @@ class Page(MPTTModel):
         """Returns smart queryset depending on object type - draft / public
         """
         qs = self.__class__.objects
-        return self.publisher_is_draft and qs.drafts() or qs.public()
+        if self.publisher_is_draft and qs.drafts().exists():
+            return qs.drafts()
+        return qs.public()
 
     def _publisher_can_publish(self):
         """Is parent of this object already published?


### PR DESCRIPTION
This is a performance improvement(even with the extra query)
that doesn't change the previous logic.

I ran get_absolute_url() for 30 root pages on a site(which can be considered a common use case when accessing the sitemap) and I got the following times:

before this change
raw times: 1.31 1.26 1.25 1.27 1.23 1.19 1.2 1.36 1.29 1.29
1 loops, best of 10: 1.19 sec per loop

after this change
raw times: 0.312 0.283 0.3 0.332 0.321 0.277 0.269 0.291 0.277 0.261
1 loops, best of 10: 261 msec per loop

It looks like it's 4 times better. 
