### PR TITLE
LUN-1966: Fix for having query param site__exact point to a site where t...

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -71,7 +71,7 @@ class CMSChangeList(ChangeList):
         except:
             raise
         self.get_results(request)
-
+        
     def get_query_set(self, request=None):
         if COPY_VAR in self.params:
             del self.params[COPY_VAR]
@@ -86,14 +86,14 @@ class CMSChangeList(ChangeList):
         if request:
             site = self._current_site
             permissions = Page.permissions.get_change_id_list(request.user, site)
-
+            
             if permissions != Page.permissions.GRANT_ALL:
                 qs = qs.filter(pk__in=permissions)
                 self.root_query_set = self.root_query_set.filter(pk__in=permissions)
             self.real_queryset = True
             qs = qs.filter(site=self._current_site)
         return qs
-
+    
     def is_filtered(self):
         from cms.utils.plugins import SITE_VAR
         lookup_params = self.params.copy() # a dictionary of the query string
@@ -111,7 +111,7 @@ class CMSChangeList(ChangeList):
                 self.full_result_count = self.result_count = self.root_query_set.count()
             else:
                 self.full_result_count = self.root_query_set.count()
-
+    
     def set_items(self, request):
         site = self._current_site
         # Get all the pages, ordered by tree ID (it's convenient to build the 
@@ -253,11 +253,11 @@ class CMSChangeList(ChangeList):
         sites combo.
         """
         if settings.CMS_PERMISSION:
-            self.sites = get_user_sites_queryset(request.user)
+            self.sites = get_user_sites_queryset(request.user)   
         else:
             self.sites = Site.objects.all()
         self.has_access_to_multiple_sites = len(self.sites) > 1
-
+    
     def current_site(self):
         return self._current_site
     

--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -71,10 +71,14 @@ class CMSChangeList(ChangeList):
         except:
             raise
         self.get_results(request)
-        
+
     def get_query_set(self, request=None):
         if COPY_VAR in self.params:
             del self.params[COPY_VAR]
+        # remove site__exact from params if it is different than the current site
+        from cms.utils.plugins import SITE_VAR
+        if SITE_VAR in self.params and self.params[SITE_VAR] != str(self._current_site.id):
+            del self.params[SITE_VAR]
         if django.VERSION[1] > 3:
             qs = super(CMSChangeList, self).get_query_set(request).drafts()
         else:
@@ -82,14 +86,14 @@ class CMSChangeList(ChangeList):
         if request:
             site = self._current_site
             permissions = Page.permissions.get_change_id_list(request.user, site)
-            
+
             if permissions != Page.permissions.GRANT_ALL:
                 qs = qs.filter(pk__in=permissions)
                 self.root_query_set = self.root_query_set.filter(pk__in=permissions)
             self.real_queryset = True
             qs = qs.filter(site=self._current_site)
         return qs
-    
+
     def is_filtered(self):
         from cms.utils.plugins import SITE_VAR
         lookup_params = self.params.copy() # a dictionary of the query string
@@ -107,7 +111,7 @@ class CMSChangeList(ChangeList):
                 self.full_result_count = self.result_count = self.root_query_set.count()
             else:
                 self.full_result_count = self.root_query_set.count()
-    
+
     def set_items(self, request):
         site = self._current_site
         # Get all the pages, ordered by tree ID (it's convenient to build the 
@@ -249,11 +253,11 @@ class CMSChangeList(ChangeList):
         sites combo.
         """
         if settings.CMS_PERMISSION:
-            self.sites = get_user_sites_queryset(request.user)   
+            self.sites = get_user_sites_queryset(request.user)
         else:
             self.sites = Site.objects.all()
         self.has_access_to_multiple_sites = len(self.sites) > 1
-    
+
     def current_site(self):
         return self._current_site
     

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -404,7 +404,7 @@ class AdminTestCase(AdminTestsBase):
         # but not any further down the tree
         self.assertFalse('id="page_4"' in response.content)
 
-    def test_changelist_site_items(self):
+    def _test_changelist_site_items(self, site_lookup=False):
         site_one = Site.objects.get_current()
         site_two = Site.objects.create(
             domain='django-cms2.org', name='django-cms2')
@@ -432,8 +432,14 @@ class AdminTestCase(AdminTestsBase):
             changelist = CMSChangeList(*tuple(cl_params))
             changelist.set_items(request)
             self.assertItemsEqual(changelist.get_items(), [one_page])
+
             # change working site
             request.session['cms_admin_site'] = site_two.id
+            if site_lookup:
+                copied_params = request.GET.copy()
+                copied_params.__setitem__('site__exact', site_two.id)
+                request.GET = copied_params
+
             changelist = CMSChangeList(*tuple(cl_params))
             changelist.set_items(request)
             self.assertItemsEqual(changelist.get_items(), [second_page])
@@ -444,6 +450,12 @@ class AdminTestCase(AdminTestsBase):
             changelist = CMSChangeList(*tuple(cl_params))
             changelist.set_items(request)
             self.assertItemsEqual(changelist.get_items(), [one_page])
+
+    def test_changelist_site_items(self):
+        self._test_changelist_site_items()
+
+    def test_changelist_site_items_with_site_lookup(self):
+        self._test_changelist_site_items(True)
 
     def test_pages_admin_access_with_global_permissions(self):
         site_one = Site.objects.get_current()


### PR DESCRIPTION
Fix for having query param site__exact point to a site where the user has no role. Removing site__exact from ChangeList params when the current site is different.
